### PR TITLE
remove About link from navbar for cleaner navigation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,13 +20,11 @@
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="#">Home</a>
           </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">About</a>
-          </li>
         </ul>
       </div>
     </div>
   </nav>
+  
 
   <!-- Content Section -->
   <div class="container mt-5 text-center">


### PR DESCRIPTION
Removed the "About" link from the navbar to simplify the navigation menu and improve user focus on the main content. This cleanup helps streamline the UI and reduces unnecessary navigation options.